### PR TITLE
Properly import ScreenOrientation

### DIFF
--- a/src/polyfill.native.ts
+++ b/src/polyfill.native.ts
@@ -1,6 +1,6 @@
 import { Subscription } from "@unimodules/core";
 import mediaQuery from "css-mediaquery";
-import ScreenOrientation from "expo/build/ScreenOrientation/ScreenOrientation";
+import * as ScreenOrientation from "expo/build/ScreenOrientation/ScreenOrientation";
 import { Dimensions } from "react-native";
 
 type Listener = (context: MediaQuery) => any;


### PR DESCRIPTION
Fixes https://github.com/expo/match-media/issues/1. ScreenOrientation now exports named functions instead of a default export.