### PR TITLE
Fix device-dimensions queries never matching

### DIFF
--- a/src/polyfill.native.ts
+++ b/src/polyfill.native.ts
@@ -53,6 +53,7 @@ class MediaQuery {
     return mediaQuery.match(this.query, {
       type: "screen",
       orientation: this.orientation.toLowerCase(),
+      ...windowDimensions,
       "device-width": windowDimensions.width,
       "device-height": windowDimensions.height,
     });

--- a/src/polyfill.native.ts
+++ b/src/polyfill.native.ts
@@ -49,10 +49,12 @@ class MediaQuery {
 
   // @ts-ignore
   public get matches(): boolean {
+    const windowDimensions = Dimensions.get("window");
     return mediaQuery.match(this.query, {
       type: "screen",
       orientation: this.orientation.toLowerCase(),
-      ...Dimensions.get("window")
+      "device-width": windowDimensions.width,
+      "device-height": windowDimensions.height,
     });
   }
 


### PR DESCRIPTION
`css-mediaquery` expects values under feature keys

https://github.com/ericf/css-mediaquery/blob/34ba6343938e72b270205447b297611c40140a4f/index.js#L37-L40