### PR TITLE
fix(peerDependencies): allow testing with `expo@^36.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/match-media",
-  "version": "0.0.0-alpha.2",
+  "version": "0.0.0-alpha.3",
   "sideEffects": true,
   "private": false,
   "description": "Universal polyfill for match media API using Expo APIs on mobile",
@@ -49,7 +49,7 @@
     "@unimodules/core": "*"
   },
   "peerDependencies": {
-    "expo": "^35.0.1",
+    "expo": "^35.0.1 || ^36.0.0",
     "react-native": "*"
   },
   "jest": {


### PR DESCRIPTION
allow testing with `expo@^36.0.0` since:

```
npm ERR! peer dep missing: expo@^35.0.1, required by @expo/match-media@0.0.0-alpha.2
```