### PR TITLE
fix(polyfill): removeListener removing too much listeners

### DIFF
--- a/src/polyfill.native.ts
+++ b/src/polyfill.native.ts
@@ -44,7 +44,7 @@ class MediaQuery {
 
   public removeListener(listener: Listener) {
     const index = this.listeners.indexOf(listener);
-    if (index !== -1) this.listeners.splice(index);
+    if (index !== -1) this.listeners.splice(index, 1);
   }
 
   // @ts-ignore


### PR DESCRIPTION
`splice` removing elements with greater index than 1st arg, if 2nd arg is not supplied.

```js
a = [1,2,3]
a.splice(1)
a // => [1]
```