### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Install `@expo/match-media` in your project.
 yarn add @expo/match-media
 ```
 
-> If you're using a React Native app that wasn't bootstrapped with the `expo-cli` then you'll need to install and link the `expo` module to use this package.
-
 ## ⚽️ Usage
 
 Import the polyfill at the top of your file before using the [`window.matchMedia` API][match-media].


### PR DESCRIPTION
According to #15 changes and after added `expo-screen-orientation` to dependencies. the quote on readme can misguided user. 
For more detail you can link to [linking process for iOS](https://github.com/expo/expo/tree/master/packages/expo-screen-orientation#add-the-package-to-your-npm-dependencies).